### PR TITLE
Feat: "추가 aop 사용하여 함수 호출 전후로 로그 찍기"

### DIFF
--- a/core/src/main/java/backend/core/CoreApplication.java
+++ b/core/src/main/java/backend/core/CoreApplication.java
@@ -1,17 +1,18 @@
 package backend.core;
 
+import backend.core.global.aop.AopConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.servlet.ServletComponentScan;
-import org.springframework.context.annotation.ComponentScans;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@Import(AopConfig.class)
 public class CoreApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(CoreApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(CoreApplication.class, args);
+    }
 
 }

--- a/core/src/main/java/backend/core/global/aop/AopConfig.java
+++ b/core/src/main/java/backend/core/global/aop/AopConfig.java
@@ -1,0 +1,20 @@
+package backend.core.global.aop;
+
+import backend.core.global.trace.logtrace.LogTrace;
+import backend.core.global.trace.logtrace.ThreadLocalLogTrace;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AopConfig {
+
+    @Bean
+    public LogTrace logTrace() {
+        return new ThreadLocalLogTrace();
+    }
+
+    @Bean
+    public LogTraceAspect logTraceAspect(LogTrace logTrace) {
+        return new LogTraceAspect(logTrace);
+    }
+}

--- a/core/src/main/java/backend/core/global/aop/LogTraceAspect.java
+++ b/core/src/main/java/backend/core/global/aop/LogTraceAspect.java
@@ -1,0 +1,36 @@
+package backend.core.global.aop;
+
+import backend.core.global.trace.TraceStatus;
+import backend.core.global.trace.logtrace.LogTrace;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+
+@Slf4j
+@Aspect
+public class LogTraceAspect {
+
+    private final LogTrace logTrace;
+
+    public LogTraceAspect(LogTrace logTrace) {
+        this.logTrace = logTrace;
+    }
+
+    @Around("backend.core.global.aop.Pointcuts.all()")
+    public Object doLogTrace(ProceedingJoinPoint joinPoint) throws Throwable {
+        TraceStatus status = null;
+        try {
+            String message = joinPoint.getSignature().toShortString();
+            status = logTrace.begin(message);
+
+            Object result = joinPoint.proceed();
+
+            logTrace.end(status);
+            return result;
+        } catch (Exception e) {
+            logTrace.exception(status, e);
+            throw e;
+        }
+    }
+}

--- a/core/src/main/java/backend/core/global/aop/Pointcuts.java
+++ b/core/src/main/java/backend/core/global/aop/Pointcuts.java
@@ -1,0 +1,34 @@
+package backend.core.global.aop;
+
+import org.aspectj.lang.annotation.Pointcut;
+
+public class Pointcuts {
+
+    @Pointcut("execution(* backend.core.post..*(..))")
+    public void allPost() {
+    }
+
+    @Pointcut("execution(* backend.core.member..*(..))")
+    public void allMember() {
+    }
+
+    @Pointcut("execution(* backend.core..*Controller.*(..))")
+    public void allController() {
+    }
+
+    @Pointcut("execution(* backend.core..*Service.*(..))")
+    public void allService() {
+    }
+
+    @Pointcut("execution(* backend.core..*Repository.*(..))")
+    public void allRepository() {
+    }
+
+    @Pointcut("allService() || allController() || allRepository()")
+    public void all() {
+    }
+
+    @Pointcut("allPost() || allMember()")
+    public void allPostOrMember() {
+    }
+}

--- a/core/src/main/java/backend/core/global/security/JwtAuthenticationFilter.java
+++ b/core/src/main/java/backend/core/global/security/JwtAuthenticationFilter.java
@@ -36,14 +36,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             String token = parseBearerToken(request);
-            String memberId = tokenProvider.validateAndGetUserId(token);
 
-            AbstractAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(memberId, null, AuthorityUtils.NO_AUTHORITIES);
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            if (token != null && !token.equalsIgnoreCase("null")) {
+                Long memberId = tokenProvider.validateAndGetUserId(token);
+                AbstractAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(memberId, null, AuthorityUtils.NO_AUTHORITIES);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-            SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-            securityContext.setAuthentication(authentication);
-            SecurityContextHolder.setContext(securityContext);
+                SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+                securityContext.setAuthentication(authentication);
+                SecurityContextHolder.setContext(securityContext);
+            }
         } catch (ExpiredJwtException e) {
             e.printStackTrace();
             log.info("expired token exception");

--- a/core/src/main/java/backend/core/global/security/TokenProvider.java
+++ b/core/src/main/java/backend/core/global/security/TokenProvider.java
@@ -31,11 +31,11 @@ public class TokenProvider {
                 .compact();
     }
 
-    public String validateAndGetUserId(String token) {
+    public Long validateAndGetUserId(String token) {
         Claims claims = Jwts.parser()
                 .setSigningKey(SECRET_KEY)
                 .parseClaimsJws(token).getBody();
 
-        return claims.getSubject();
+        return Long.parseLong(claims.getSubject());
     }
 }

--- a/core/src/main/java/backend/core/global/trace/TraceId.java
+++ b/core/src/main/java/backend/core/global/trace/TraceId.java
@@ -1,0 +1,38 @@
+package backend.core.global.trace;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class TraceId {
+
+    private String id;
+    private int level;
+
+    public TraceId() {
+        this.id = createId();
+        this.level = 0;
+    }
+
+    private TraceId(String id, int level) {
+        this.id = id;
+        this.level = level;
+    }
+
+    public TraceId createNextId() {
+        return new TraceId(id, level + 1);
+    }
+
+    public TraceId createPreviousId() {
+        return new TraceId(id, level - 1);
+    }
+
+    public Boolean isFirstLevel() {
+        return level == 0;
+    }
+
+    private String createId() {
+        return UUID.randomUUID().toString().substring(0, 8);
+    }
+}

--- a/core/src/main/java/backend/core/global/trace/TraceStatus.java
+++ b/core/src/main/java/backend/core/global/trace/TraceStatus.java
@@ -1,0 +1,17 @@
+package backend.core.global.trace;
+
+import lombok.Getter;
+
+@Getter
+public class TraceStatus {
+
+    private TraceId traceId;
+    private Long startTimeMs;
+    private String message;
+
+    public TraceStatus(TraceId traceId, Long startTimeMs, String message) {
+        this.traceId = traceId;
+        this.startTimeMs = startTimeMs;
+        this.message = message;
+    }
+}

--- a/core/src/main/java/backend/core/global/trace/logtrace/LogTrace.java
+++ b/core/src/main/java/backend/core/global/trace/logtrace/LogTrace.java
@@ -1,0 +1,9 @@
+package backend.core.global.trace.logtrace;
+
+import backend.core.global.trace.TraceStatus;
+
+public interface LogTrace {
+    TraceStatus begin(String message);
+    void end(TraceStatus status);
+    void exception(TraceStatus status, Exception e);
+}

--- a/core/src/main/java/backend/core/global/trace/logtrace/ThreadLocalLogTrace.java
+++ b/core/src/main/java/backend/core/global/trace/logtrace/ThreadLocalLogTrace.java
@@ -1,0 +1,77 @@
+package backend.core.global.trace.logtrace;
+
+import backend.core.global.trace.TraceId;
+import backend.core.global.trace.TraceStatus;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ThreadLocalLogTrace implements LogTrace {
+
+    private static final String START_PREFIX = "-->";
+    private static final String COMPLETE_PREFIX = "<--";
+    private static final String EX_PREFIX = "<x-";
+
+    private final ThreadLocal<TraceId> traceIdHolder = new ThreadLocal<>();
+
+    @Override
+    public TraceStatus begin(String message) {
+        syncTraceId();
+        TraceId traceId = traceIdHolder.get();
+        long startTimeMs = System.currentTimeMillis();
+        log.info("[{}] {}{}", traceId.getId(), addSpace(START_PREFIX, traceId.getLevel()), message);
+        return new TraceStatus(traceId, startTimeMs, message);
+    }
+
+    @Override
+    public void end(TraceStatus status) {
+        complete(status, null);
+    }
+
+    @Override
+    public void exception(TraceStatus status, Exception e) {
+        complete(status, e);
+    }
+
+    private void complete(TraceStatus status, Exception e) {
+        long stopTimeMs = System.currentTimeMillis();
+
+        long resultTimeMs = stopTimeMs - status.getStartTimeMs();
+        TraceId traceId = status.getTraceId();
+        if (e == null) {
+            log.info("[{}] {}{} time={}ms",
+                    traceId.getId(), addSpace(COMPLETE_PREFIX, traceId.getLevel()), status.getMessage(), resultTimeMs);
+        } else {
+            log.info("[{}] {}{} time={}ms ex={}",
+                    traceId.getId(), addSpace(EX_PREFIX, traceId.getLevel()), status.getMessage(), resultTimeMs, e.toString());
+        }
+        releaseTraceId();
+    }
+
+    private void releaseTraceId() {
+        TraceId traceId = traceIdHolder.get();
+
+        if (traceId.isFirstLevel()) {
+            traceIdHolder.remove();
+        } else {
+            traceIdHolder.set(traceId.createPreviousId());
+        }
+    }
+
+    private String addSpace(String prefix, int level) {
+        StringBuffer sb = new StringBuffer();
+
+        for (int i = 0; i < level; i++) {
+            sb.append((i == level - 1) ? "|" + prefix : "|    ");
+        }
+        return sb.toString();
+    }
+
+    private void syncTraceId() {
+        TraceId traceId = traceIdHolder.get();
+        if (traceId == null) {
+            traceIdHolder.set(new TraceId());
+        } else {
+            traceIdHolder.set(traceId.createNextId());
+        }
+    }
+}


### PR DESCRIPTION
### 설명
- pointcut을 사용하여 controller->service->repository->service->controller의 계층간 함수 호출 정보를 출력하는 logTrace 기능 추가
- token이 null 일 경우 validateAndGetUserId가 동작하지 않아 token이 null일 경우 추가
- authentication의 principal을 String으로 설정하여 String으로 받아 parseLong을 해주던 부분을 principal에서 부터 Long으로 저장될 수 있도록 설정